### PR TITLE
(fix) Add error checking for when user has not attempted a problem

### DIFF
--- a/client/app/components/dashboard/dashboardController.js
+++ b/client/app/components/dashboard/dashboardController.js
@@ -16,7 +16,7 @@ angular.module('RecallJS')
         });
     };
 
-    $scope.username = "TODO: Replace with actual username";
+    $scope.username = JSON.parse($window.localStorage.getItem('com.recalljs')).username;
     $scope.calcWeight = LearningAlgo.calculateWeight;
     $scope.lastAttempted = LearningAlgo.getLastAttemptDate;
     $scope.avgRating = LearningAlgo.calcAverageRating;

--- a/client/app/shared/learningAlgoService.js
+++ b/client/app/shared/learningAlgoService.js
@@ -81,8 +81,16 @@ function LearningAlgo($window) {
   }
 
   function calcAgeWeight(problem) {
+    
+    var attempts = problem.attempts;
+    
+    // error checking if user has not attempted problem
+    if (attempts.length === 0) {
+      return 1;
+    }
+
     // identify number of days since last attempt
-    var timeLastAttempt = problem.attempts.slice(-1)[0].timeSubmitted; // assuming last attempt is most recent
+    var timeLastAttempt = attempts.slice(-1)[0].timeSubmitted; // assuming last attempt is most recent
     var currTime = (new Date()).getTime(); // in milliseconds
     var daysSince = convertMStoDAYS(currTime - timeLastAttempt);
 
@@ -91,6 +99,13 @@ function LearningAlgo($window) {
   }                                  // since the last attempt
 
   function calcProgressWeight(problem) {
+    
+    var attempts = problem.attempts;
+    // error checking if user has not attempted problem
+    if (attempts.length === 0) {
+      return 1;
+    }
+
     // calculate and return weight
     var avgRating = calcAverageRating(problem.attempts, 10); // calculate avg rating of last 10 attempts
     return Math.pow(0.5, 5 * avgRating); // weight will halve every time the
@@ -117,7 +132,14 @@ function LearningAlgo($window) {
   }
 
   function calcEffortWeight(problem) {
-    var mostRecentAttempt = problem.attempts.slice(-1)[0];
+    var attempts = problem.attempts;
+    
+    // error checking if user has not attempted problem
+    if (attempts.length === 0) {
+      return 1;
+    }
+
+    var mostRecentAttempt = attempts.slice(-1)[0];
     var rating = mostRecentAttempt.rating;
     return rating ? 1 : 10; // if rating is non-zero, return 1, else 10
   }
@@ -145,6 +167,12 @@ function LearningAlgo($window) {
   // TODO: Refactor and place in a utilities or stats Service
   function getLastAttemptDate(problem) {
     var attempts = problem.attempts;
+
+    // error checking if user has not attempted problem
+    if (attempts.length === 0) {
+      return "Not yet attempted";
+    }
+
     var timeLastAttempt = attempts[attempts.length-1].timeSubmitted;
     return timeLastAttempt;
   }

--- a/client/app/shared/learningAlgoService.js
+++ b/client/app/shared/learningAlgoService.js
@@ -100,6 +100,11 @@ function LearningAlgo($window) {
   // helper function to calculate the average of the most recent ratings
   function calcAverageRating(attempts, numToAverage) {
 
+    // error checking if no attempts have occurred
+    if (attempts.length === 0) {
+      return 0;
+    }
+
     // identify the most recent ratings
     var recentAttempts = attempts.slice(-numToAverage);
     var ratings = recentAttempts.map(function(attempt){


### PR DESCRIPTION
This pull request adds some simple error checking to see if a user has attempted a problem.

In addition, it grabs the user's name from local storage and displays it on their dashboard.
